### PR TITLE
Update for Livewire 3 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "livewire/livewire": ">=2.0"
+        "php": ">=8.0",
+        "livewire/livewire": ">=3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "orchestra/testbench": "^6.0",
-        "livewire/livewire": "^2.0"
+        "livewire/livewire": "^3.0"
     },    
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          forceCoversAnnotation="false"
          beStrictAboutCoversAnnotation="true"

--- a/src/Traits/HasSelect2Wire.php
+++ b/src/Traits/HasSelect2Wire.php
@@ -6,6 +6,6 @@ trait HasSelect2Wire
 {
     public function initSelect2()
     {
-        $this->dispatchBrowserEvent('select2wire.init');
+        $this->dispatch('select2wire.init');        
     }
 }

--- a/tests/Livewire/Select2WireTraitTest.php
+++ b/tests/Livewire/Select2WireTraitTest.php
@@ -27,6 +27,6 @@ class Select2WireTraitTest extends TestCase
     public function it_dispatches_browser_event_from_trait()
     {
         Livewire::test(ComponentUsingTrait::class)
-            ->assertDispatchedBrowserEvent('select2wire.init');
+            ->assertDispatched('select2wire.init');
     }
 }


### PR DESCRIPTION
Livewire 3 no longer uses dispatchBrowserEvent or emit, replaced with dispatch